### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xee" %}
-{% set version = "0.0.0" %}
+{% set version = "0.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/xee-{{ version }}.tar.gz
-  sha256: b719e78d8e940b302c68a0c15bc37a0ea64efb6dc1499c0ff63dca5a1cdc920b
+  sha256: 75ecf23cd9a0261c676457d544498152877a58a69e6922771089fbd7a328ac5d
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -20,10 +20,11 @@ requirements:
     - pip
   run:
     - python >=3.9
-    - xarray
-    - earthengine-api >=0.1.374
-    - pyproj
     - affine
+    - earthengine-api >=0.1.374
+    - gcloud
+    - pyproj
+    - xarray
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - python >=3.9
     - affine
     - earthengine-api >=0.1.374
-    - gcloud
     - pyproj
     - xarray
 


### PR DESCRIPTION
Add gcloud and bump version 

Trying installing this and got

```

❯ earthengine authenticate

Fetching credentials using gcloud
Traceback (most recent call last):
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/oauth.py", line 317, in _load_app_default_credentials
    subprocess.run(command, check=True)
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'gcloud'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/ray/miniforge3/envs/test_env/bin/earthengine", line 10, in <module>
    sys.exit(main())
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/cli/eecli.py", line 87, in main
    _run_command()
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/cli/eecli.py", line 61, in _run_command
    dispatcher.run(args, config)
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/cli/commands.py", line 361, in run
    self.command_dict[vars(args)[self.dest]].run(args, config)
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/cli/commands.py", line 406, in run
    ee.Authenticate(**args_auth)
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/__init__.py", line 104, in Authenticate
    oauth.authenticate(
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/oauth.py", line 422, in authenticate
    _load_app_default_credentials(auth_mode == 'gcloud', scopes, quiet)
  File "/Users/ray/miniforge3/envs/test_env/lib/python3.10/site-packages/ee/oauth.py", line 320, in _load_app_default_credentials
    raise Exception('gcloud command not found. ' + tip) from e  # pylint:disable=broad-exception-raised
Exception: gcloud command not found. Please ensure that gcloud is installed.
More information: https://developers.google.com/earth-engine/guides/python_install

```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
