### PR TITLE
Update xee to 0.1.0 and add shapely runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xee" %}
-{% set version = "0.0.24" %}
+{% set version = "0.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/xee-{{ version }}.tar.gz
-  sha256: 93ff9719527a5a9fea43b6e8ee439ebc6172edbcec7d2c1f677a7deecc0e90de
+  sha256: fa931cf95719180da7dbeb455bd727d39b7f5dab9e6778f1dfdaf954937483d0
 
 build:
   noarch: python
@@ -22,8 +22,9 @@ requirements:
   run:
     - python >={{ python_min }}
     - affine
-    - earthengine-api >=0.1.374
+    - earthengine-api >=1.6.12
     - pyproj
+    - shapely
     - xarray
     - dask
 


### PR DESCRIPTION
This PR syncs the feedstock with the recent upstream Xee release and fixes the missing runtime dependency reported in #31.

## Changes
- Bump `xee` from `0.0.24` to `0.1.0`
- Update source `sha256` for `0.1.0` sdist
- Update `earthengine-api` lower bound to `>=1.6.12` (matches upstream metadata)
- Add `shapely` to runtime requirements

## Why
- Upstream Xee has a significant update in `0.1.0`
- `shapely` is required at runtime and was missing from the feedstock recipe, causing import/test failures on conda-forge CI

Closes #31.