### PR TITLE
Fix xee runtime version metadata in conda build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,14 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
     - python {{ python_min }}
     - pip
     - setuptools
+    - setuptools_scm
   run:
     - python >={{ python_min }}
     - affine


### PR DESCRIPTION
## Summary

Fixes #34: xee runtime version metadata now correctly reports 0.1.0

## Changes

- Added `setuptools_scm` to host requirements in the conda recipe
- Bumped build number from 0 to 1

## Rationale

The conda package was installing as 0.1.0 (correct conda version), but runtime metadata APIs reported 0.0.0 (incorrect). This was caused by the recipe building with `--no-build-isolation`, which requires build-time dependencies to be present in the host environment.

Upstream xee uses dynamic versioning via setuptools_scm. Without it present during the no-isolation build, Python package metadata fell back to 0.0.0. Adding setuptools_scm to host requirements ensures the version backend is available and produces correct dist-info metadata.

## Validation

Built locally and tested in a clean environment:

✓ Built artifact contains `xee-0.1.0.dist-info/METADATA` with `Version: 0.1.0`
✓ `importlib.metadata.version("xee")` returns `0.1.0`
✓ `xee.__version__` returns `0.1.0`

The build number bump to 1 signals conda solvers to prefer this corrected package over the previous build 0.
