### PR TITLE
Use python_min Jinja override for noarch Python pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "xee" %}
 {% set version = "0.1.1" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.11
+    - python {{ python_min }}
     - pip
     - setuptools
     - setuptools_scm
   run:
-    - python >=3.11
+    - python >={{ python_min }}
     - affine
     - earthengine-api >=1.6.12
     - pyproj
@@ -36,7 +37,7 @@ test:
     - pip check
   requires:
     - pip
-    - python >=3.11
+    - python {{ python_min }}
 
 about:
   home: https://github.com/google/xee


### PR DESCRIPTION
## Summary
Refactor `recipe/meta.yaml` to follow the recommended noarch Python pinning pattern while keeping the effective minimum Python version at 3.11.

## Changes
- Add a local Jinja override:
  - `{% set python_min = "3.11" %}`
- Use standard noarch pin syntax:
  - host: `python {{ python_min }}`
  - run: `python >={{ python_min }}`
  - test: `python {{ python_min }}`

## Notes
- No package version change.
- No build number change.
- Effective runtime floor remains Python >=3.11.
- This is a metadata/style alignment with conda-forge guidance, not a functional dependency change.